### PR TITLE
Import/export pls::scores so the S3 method can be used

### DIFF
--- a/ChemometricsWithR/NAMESPACE
+++ b/ChemometricsWithR/NAMESPACE
@@ -1,5 +1,5 @@
 ## Import all packages listed as Imports or Depends
-importFrom("pls", "MSEP", "plsr")
+importFrom("pls", "MSEP", "plsr", "scores")
 importFrom("kohonen", "classvec2classmat", "classmat2classvec")
 importFrom("devtools", "install_github")
 importFrom("MASS", "lda", "ginv")
@@ -14,7 +14,7 @@ exportPattern("PCA", "variances", "screeplot", "reconstruct", "project",
               "efa", "opa", "mcr", "SAstep", "SAfun", "SAfun2",
               "GA.init.pop", "GA.select", "GA.XO", "GA.mut", "GAfun",
               "GAfun2", "lda.loofun", "pls.cvfun", "AdjRkl", "rms",
-              "err.rate", "gini", "pick.peaks",
+              "err.rate", "gini", "pick.peaks", "scores",
               "scoreplot", "loadingplot", "loadings", 
               "installChemometricsWithRData")
 S3method("biplot", "PCA")


### PR DESCRIPTION
Since the package defines the S3 method `scores.PCA` and it imports `pls` functions, it makes sense to re-export the `scores` function from the `pls` package so the following example still works and finds the `scores.PCA` method as expected. It makes sense, given that we are exporting `loadings` as well.

```r
library(ChemometricsWithR)
data(wines, package = "kohonen")
wines.PC <- PCA(scale(wines))
scores_mat <- scores(wines.PC) # with ChemometricsWithR from 2015 worked, in 2017 failed.
```

